### PR TITLE
Add installation of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You will need a Sanity account to use this starter. You can create a new account
    1. In your _Gatsby site's directory_, to create `.env.development` and `.env.production` files with configuration for your Sanity project, run:
 
       ```sh
-      yarn setup
+      yarn && yarn setup
       ```
 
 1. **Start developing**


### PR DESCRIPTION
Before running yarn setup, it's important that all dependencies are installed for the Gatsby site, otherwise the user will receive an error like the following 

```
$ node ./scripts/setup.js
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module 'configstore'
Require stack:
- /Users/patricksullivan/code/gatsby/gatsby-starter-sanity-homepage/scripts/setup.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:999:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/Users/patricksullivan/code/gatsby/gatsby-starter-sanity-homepage/scripts/setup.js:2:21)
    at Module._compile (node:internal/modules/cjs/loader:1099:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/patricksullivan/code/gatsby/gatsby-starter-sanity-homepage/scripts/setup.js'
  ]
}

Node.js v17.8.0
error Command failed with exit code 1
```
